### PR TITLE
Reannounce to tracker before removing torrent

### DIFF
--- a/autoremoveplus/core.py
+++ b/autoremoveplus/core.py
@@ -198,8 +198,11 @@ class Core(CorePluginBase):
                 "AutoRemovePlus: Problems pausing torrent: %s", e
             )
 
-    def remove_torrent(self, torrentmanager, tid, remove_data):
+    def remove_torrent(self, torrentmanager, torrent, tid, remove_data):
         try:
+            torrent.pause()
+            torrent.resume()
+            time.sleep(2)
             torrentmanager.remove(tid, remove_data=remove_data)
         except Exception, e:
             log.warn(
@@ -375,7 +378,7 @@ class Core(CorePluginBase):
                     if not remove:
                         self.pause_torrent(t)
                     else:
-                        if self.remove_torrent(torrentmanager, i, remove_data):
+                        if self.remove_torrent(torrentmanager, t, i, remove_data):
                             changed = True
 
         # If a torrent exemption state has been removed save changes


### PR DESCRIPTION
Been using the plugin and noticed that sometimes the tracker isn't fully updated before auto-removing a torrent (e.g. uploaded 500MB but tracker says 450MB).
So I added a functionality to pause and resume a torrent before removing it so the tracker will get updated stats.
Thought about 'component.get("Core").force_reannounce(torrent_id)', but it doesn't work ok (Next announce is not updated so I think it's somehow broken).
The sleep delay is there to give the tracker a chance to be updated, though I think it can be optimized.
